### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use strict';
-var gutil       = require('gulp-util');
+var log         = require('fancy-log');
 var through     = require('through2');
 var fileSystem  = require("fs");
 var archiver    = require('archiver');
 var mkdirp      = require('mkdirp');
 var builder     = require('xmlbuilder');
+var PluginError = require('plugin-error');
 var _           = require("lodash");
 var colors      = require("colors");
 
@@ -29,7 +30,7 @@ function generateParametersXml(options){
 }
 
 function createPackage(options, callback) {
-      gutil.log("Starting...".green);
+      log("Starting...".green);
 
         if( !_.endsWith(options.source, '/') ){
           options.source = options.source + "/";
@@ -41,23 +42,23 @@ function createPackage(options, callback) {
 
       if(options.enabled){
         mkdirp(options.dest, function(err) {
-            gutil.log("WARNING: Failed to create folder '".yellow + options.dest.red.bold + "' or the directory already exists.".yellow);
+            log("WARNING: Failed to create folder '".yellow + options.dest.red.bold + "' or the directory already exists.".yellow);
         });
 
-        gutil.log('Creating web deploy package "' + options.dest.magenta + options.package.magenta.bold + '" from the directory "' + options.source.magenta + '"');
+        log('Creating web deploy package "' + options.dest.magenta + options.package.magenta.bold + '" from the directory "' + options.source.magenta + '"');
 
         var output = fileSystem.createWriteStream(options.dest + options.package);
         var archive = archiver('zip');
-        gutil.log("Archiving...".yellow);
+        log("Archiving...".yellow);
 
         output.on('close', function () {
-          gutil.log(archive.pointer() + ' total bytes');
-          gutil.log("Package '" + options.dest.magenta + options.package.magenta.bold + ", created");
+          log(archive.pointer() + ' total bytes');
+          log("Package '" + options.dest.magenta + options.package.magenta.bold + ", created");
           callback();
         });
 
         archive.on('error', function(err){
-            gutil.log(err.toString().red);
+            log(err.toString().red);
             callback();
         });
 
@@ -101,10 +102,10 @@ module.exports = function (options) {
   }
 
 	return through.obj(function (file, enc, callback) {
-        gutil.log('Initializing...');  
-        
+        log('Initializing...');
+
         if (file.isStream()) {
-            throw gutil.PluginError("gulp-mswebdeploy-package", "Stream is not supported");
+            throw PluginError("gulp-mswebdeploy-package", "Stream is not supported");
             return callback();
         }
       

--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
   "dependencies": {
     "archiver": "^0.21.0",
     "colors": "^1.1.2",
-    "gulp-util": "^3.0.1",
+    "fancy-log": "^1.1.0",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
+    "plugin-error": "^1.0.1",
     "through2": "^0.6.3",
     "xmlbuilder": "^4.2.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "vinyl": "^0.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict';
 var assert = require('assert');
-var gutil = require('gulp-util');
+var File = require('vinyl');
 var mswebdeploy = require('./index.js');
 
 it('should ', function (cb) {
@@ -13,10 +13,11 @@ it('should ', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new File({
 		base: __dirname,
 		path: __dirname + '/file.ext',
-		contents: new Buffer('unicorns')
+		// Buffer() constructor is deprecated; use Buffer.from if available
+		contents: (Buffer.from ? Buffer.from('unicorns') : new Buffer('unicorns'))
 	}));
 
 	stream.end();


### PR DESCRIPTION
The gulp-util package is deprecated, and the Gulp team recommends using its dependencies directly. This PR replaces usages of gulp-util with the recommended replacements.

Also, in the test script, the `Buffer()` constructor is deprecated in Node.js. This commit uses the recommended `Buffer.from()` function instead, if available.

Fixes: #3